### PR TITLE
[BUGFIX] Fix duplicate anchor names in documentation

### DIFF
--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-1/Lesson-2.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-1/Lesson-2.rst
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d1-l2-resources:
+.. _s0-d1-l2-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d1-l2-teacher:
+.. _s0-d1-l2-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d1-l2-student:
+.. _s0-d1-l2-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-1/Lesson-4.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-1/Lesson-4.rst
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d1-l4-resources:
+.. _s0-d1-l4-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d1-l4-teacher:
+.. _s0-d1-l4-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d1-l4-student:
+.. _s0-d1-l4-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-1/Lesson-6.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-1/Lesson-6.rst
@@ -49,7 +49,7 @@ Before you start this lesson, please have the following things ready:
 Goals
 -----
 
-.. _s5-d1-l6-theoretical-goals:
+.. _s0-d1-l6-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d1-l6-practical-goals:
+.. _s0-d1-l6-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d1-l6-resources:
+.. _s0-d1-l6-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d1-l6-teacher:
+.. _s0-d1-l6-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d1-l6-student:
+.. _s0-d1-l6-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Index.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s0-d1:
+.. _s0-d2:
 
 ===============================================
 Day 2 — TYPO3 Ecosystem: Tools and Technologies
 ===============================================
 
-.. _s0-d1-lessons:
+.. _s0-d2-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-1.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-1.rst
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d2-l1-goals:
+.. _s0-d2-l1-goals:
 
 Goals
 -----
 
-.. _s5-d2-l1-theoretical-goals:
+.. _s0-d2-l1-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d2-l1-practical-goals:
+.. _s0-d2-l1-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d2-l1-resources:
+.. _s0-d2-l1-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l1-teacher:
+.. _s0-d2-l1-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l1-student:
+.. _s0-d2-l1-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-2.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-2.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d2-l2:
+.. _s0-d2-l2:
 
 ===================================================
 Lesson 2 — Introduction to Development Environments
@@ -8,19 +8,19 @@ Lesson 2 — Introduction to Development Environments
 
 A side-by-side comparison demonstrating the differences between development and production environments. The presentation will show how changes can be safely implemented in development before moving to production. This practical demonstration will illustrate why separate environments are essential for professional TYPO3 implementations.
 
-.. _s5-d2-l2-prerequisites-goals:
+.. _s0-d2-l2-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d2-l2-prerequisites:
+.. _s0-d2-l2-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d2-l2-theoretical-prerequisites:
+.. _s0-d2-l2-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d2-l2-practical-prerequisites:
+.. _s0-d2-l2-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d2-l2-goals:
+.. _s0-d2-l2-goals:
 
 Goals
 -----
 
-.. _s5-d2-l2-theoretical-goals:
+.. _s0-d2-l2-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d2-l2-practical-goals:
+.. _s0-d2-l2-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d2-l2-resources:
+.. _s0-d2-l2-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l2-teacher:
+.. _s0-d2-l2-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l2-student:
+.. _s0-d2-l2-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-3.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-3.rst
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d2-l3-practical-prerequisites:
+.. _s0-d2-l3-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d2-l3-goals:
+.. _s0-d2-l3-goals:
 
 Goals
 -----
 
-.. _s5-d2-l3-theoretical-goals:
+.. _s0-d2-l3-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d2-l3-practical-goals:
+.. _s0-d2-l3-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d2-l3-resources:
+.. _s0-d2-l3-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l3-teacher:
+.. _s0-d2-l3-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l3-student:
+.. _s0-d2-l3-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-4.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-4.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d2-l4:
+.. _s0-d2-l4:
 
 ============================================
 Lesson 4 — Local Development Tools for TYPO3
@@ -8,19 +8,19 @@ Lesson 4 — Local Development Tools for TYPO3
 
 A showcase of specialized tools for TYPO3 development in operation. The demonstration will reveal how these tools simplify environment setup and standardize development processes. Particular emphasis will be placed on features specifically relevant to TYPO3 projects through practical examples.
 
-.. _s5-d2-l4-prerequisites-goals:
+.. _s0-d2-l4-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d2-l4-prerequisites:
+.. _s0-d2-l4-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d2-l4-theoretical-prerequisites:
+.. _s0-d2-l4-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d2-l4-practical-prerequisites:
+.. _s0-d2-l4-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d2-l4-goals:
+.. _s0-d2-l4-goals:
 
 Goals
 -----
 
-.. _s5-d2-l4-theoretical-goals:
+.. _s0-d2-l4-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d2-l4-practical-goals:
+.. _s0-d2-l4-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d2-l4-resources:
+.. _s0-d2-l4-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l4-teacher:
+.. _s0-d2-l4-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l4-student:
+.. _s0-d2-l4-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-5.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-5.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d2-l5:
+.. _s0-d2-l5:
 
 ===========================================
 Lesson 5 — Package Management with Composer
@@ -8,19 +8,19 @@ Lesson 5 — Package Management with Composer
 
 A live demonstration of Composer in action, installing TYPO3 and managing extensions through dependency commands. The showcase will include dependency resolution, package updates, and environment consistency management. This practical demonstration will illustrate dependency management concepts in accessible terms.
 
-.. _s5-d2-l5-prerequisites-goals:
+.. _s0-d2-l5-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d2-l5-prerequisites:
+.. _s0-d2-l5-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d2-l5-theoretical-prerequisites:
+.. _s0-d2-l5-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d2-l5-practical-prerequisites:
+.. _s0-d2-l5-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d2-l5-goals:
+.. _s0-d2-l5-goals:
 
 Goals
 -----
 
-.. _s5-d2-l5-theoretical-goals:
+.. _s0-d2-l5-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d2-l5-practical-goals:
+.. _s0-d2-l5-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d2-l5-resources:
+.. _s0-d2-l5-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l5-teacher:
+.. _s0-d2-l5-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l5-student:
+.. _s0-d2-l5-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-6.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-6.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d2-l6:
+.. _s0-d2-l6:
 
 ==========================================
 Lesson 6 — Version Control Basics with Git
@@ -8,19 +8,19 @@ Lesson 6 — Version Control Basics with Git
 
 A hands-on demonstration of Git's fundamental operations in a TYPO3 development context. Changes will be committed, branches created, and code merged to illustrate version control workflows. This practical showcase will demonstrate how Git supports collaborative development of TYPO3 projects in a beginner-friendly manner.
 
-.. _s5-d2-l6-prerequisites-goals:
+.. _s0-d2-l6-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d2-l6-prerequisites:
+.. _s0-d2-l6-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d2-l6-theoretical-prerequisites:
+.. _s0-d2-l6-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d2-l6-practical-prerequisites:
+.. _s0-d2-l6-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d2-l6-goals:
+.. _s0-d2-l6-goals:
 
 Goals
 -----
 
-.. _s5-d2-l6-theoretical-goals:
+.. _s0-d2-l6-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d2-l6-practical-goals:
+.. _s0-d2-l6-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d2-l6-resources:
+.. _s0-d2-l6-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l6-teacher:
+.. _s0-d2-l6-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l6-student:
+.. _s0-d2-l6-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-7.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-2/Lesson-7.rst
@@ -20,7 +20,7 @@ Prerequisites
 -------------
 
 
-.. _s5-d2-l7-theoretical-prerequisites:
+.. _s0-d2-l7-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,7 +30,7 @@ This lesson assumes that you already know the following:
 * The content of today's previous lessons.
 
 
-.. _s5-d2-l7-l7-practical-prerequisites:
+.. _s0-d2-l7-l7-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,12 +41,12 @@ Before you start this lesson, please have the following things ready:
 * A list of any uncompleted tasks from previous lessons (if any) and what you need from the teacher to complete them.
 
 
-.. _s5-d2-l7-goals:
+.. _s0-d2-l7-goals:
 
 Goals
 -----
 
-.. _s5-d2-l7-theoretical-goals:
+.. _s0-d2-l7-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -58,7 +58,7 @@ By the end of this lesson, you should know the following:
 * What to expect for tomorrow.
 
 
-.. _s5-d2-l7-practical-goals:
+.. _s0-d2-l7-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -68,7 +68,7 @@ By the end of this lesson, you should have completed the following:
 * You should have completed any outstanding tasks or know what to do in order to complete them.
 
 
-.. _s5-d2-l7-resources:
+.. _s0-d2-l7-resources:
 
 Learning resources
 ==================
@@ -77,13 +77,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d2-l7-teacher:
+.. _s0-d2-l7-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d2-l7-student:
+.. _s0-d2-l7-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Index.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s0-d3:
 
 ===============================================
 Day 3 — Content Creation and Management Preview
 ===============================================
 
-.. _s5-d1-lessons:
+.. _s0-d3-lessons:
 
 Today's lessons
 ===============
@@ -25,19 +25,19 @@ This day features hands-on demonstrations of TYPO3's content management capabili
     Lesson-7
 
 
-.. _s5-d3-prerequisites-goals:
+.. _s0-d3-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-prerequisites:
+.. _s0-d3-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-theoretical-prerequisites:
+.. _s0-d3-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +49,7 @@ This day assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-practical-prerequisites:
+.. _s0-d3-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,12 +61,12 @@ Before you start this day, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-goals:
+.. _s0-d3-goals:
 
 Goals
 -----
 
-.. _s5-d3-theoretical-goals:
+.. _s0-d3-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ By the end of this day, you should know the following:
 * Item 3
 
 
-.. _s5-d3-practical-goals:
+.. _s0-d3-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-1.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-1.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l1:
+.. _s0-d3-l1:
 
 ======================================
 Lesson 1 — The TYPO3 Backend Interface
@@ -8,19 +8,19 @@ Lesson 1 — The TYPO3 Backend Interface
 
 A comprehensive walkthrough of the TYPO3 backend interface in action. The demonstration will navigate through various modules, showing how to access key functionality while highlighting the logical organization of the system. The session will include creating a new page, accessing the file system, and utilizing the extension manager to provide a concrete understanding of TYPO3's administrative environment.
 
-.. _s5-d3-l1-prerequisites-goals:
+.. _s0-d3-l1-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l1-prerequisites:
+.. _s0-d3-l1-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l1-theoretical-prerequisites:
+.. _s0-d3-l1-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-l1-practical-prerequisites:
+.. _s0-d3-l1-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-l1-goals:
+.. _s0-d3-l1-goals:
 
 Goals
 -----
 
-.. _s5-d3-l1-theoretical-goals:
+.. _s0-d3-l1-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d3-l1-practical-goals:
+.. _s0-d3-l1-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d3-l1-resources:
+.. _s0-d3-l1-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l1-teacher:
+.. _s0-d3-l1-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l1-student:
+.. _s0-d3-l1-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-2.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-2.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l2:
+.. _s0-d3-l2:
 
 ============================================
 Lesson 2 — Page Structure and Site Hierarchy
@@ -8,19 +8,19 @@ Lesson 2 — Page Structure and Site Hierarchy
 
 A practical demonstration focusing on TYPO3's hierarchical page structure. The session will showcase the construction of a multi-level website hierarchy, illustrating how parent-child relationships affect navigation, permissions, and content inheritance. The demonstration will include moving, copying, hiding, and deleting pages to provide a visual understanding of site structure management in TYPO3.
 
-.. _s5-d3-l2-prerequisites-goals:
+.. _s0-d3-l2-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l2-prerequisites:
+.. _s0-d3-l2-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l2-theoretical-prerequisites:
+.. _s0-d3-l2-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-l2-practical-prerequisites:
+.. _s0-d3-l2-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-l2-goals:
+.. _s0-d3-l2-goals:
 
 Goals
 -----
 
-.. _s5-d3-l2-theoretical-goals:
+.. _s0-d3-l2-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d3-l2-practical-goals:
+.. _s0-d3-l2-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d3-l2-resources:
+.. _s0-d3-l2-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l2-teacher:
+.. _s0-d3-l2-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l2-student:
+.. _s0-d3-l2-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-3.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-3.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l3:
+.. _s0-d3-l3:
 
 ==================================================
 Lesson 3 — Content Elements and Their Applications
@@ -8,19 +8,19 @@ Lesson 3 — Content Elements and Their Applications
 
 A hands-on showcase of TYPO3's content elements being created and configured. The demonstration will include text, image, multimedia, and interactive elements, showing how each serves different communication needs. Each element will be configured, positioned, and displayed to demonstrate the flexibility of TYPO3's content building blocks.
 
-.. _s5-d3-l3-prerequisites-goals:
+.. _s0-d3-l3-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l3-prerequisites:
+.. _s0-d3-l3-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l3-theoretical-prerequisites:
+.. _s0-d3-l3-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-l3-practical-prerequisites:
+.. _s0-d3-l3-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-l3-goals:
+.. _s0-d3-l3-goals:
 
 Goals
 -----
 
-.. _s5-d3-l3-theoretical-goals:
+.. _s0-d3-l3-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d3-l3-practical-goals:
+.. _s0-d3-l3-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d3-l3-resources:
+.. _s0-d3-l3-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l3-teacher:
+.. _s0-d3-l3-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l3-student:
+.. _s0-d3-l3-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-4.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-4.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l4:
+.. _s0-d3-l4:
 
 ====================================
 Lesson 4 — Media Management in TYPO3
@@ -8,19 +8,19 @@ Lesson 4 — Media Management in TYPO3
 
 A practical demonstration of TYPO3's media handling capabilities in action. The session will include uploading various file types, creating folder structures, and implementing media assets within content elements. The demonstration will showcase how images are cropped, scaled, and optimized automatically, illustrating TYPO3's powerful digital asset management capabilities.
 
-.. _s5-d3-l4-prerequisites-goals:
+.. _s0-d3-l4-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l4-prerequisites:
+.. _s0-d3-l4-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l4-theoretical-prerequisites:
+.. _s0-d3-l4-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-l4-practical-prerequisites:
+.. _s0-d3-l4-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-l4-goals:
+.. _s0-d3-l4-goals:
 
 Goals
 -----
 
-.. _s5-d3-l4-theoretical-goals:
+.. _s0-d3-l4-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d3-l4-practical-goals:
+.. _s0-d3-l4-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d3-l4-resources:
+.. _s0-d3-l4-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l4-teacher:
+.. _s0-d3-l4-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l4-student:
+.. _s0-d3-l4-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-5.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-5.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l5:
+.. _s0-d3-l5:
 
 =============================================
 Lesson 5 — User Roles and Editorial Workflows
@@ -8,19 +8,19 @@ Lesson 5 — User Roles and Editorial Workflows
 
 A live demonstration of user management and workflow processes in TYPO3. The session will include creating different user types, assigning varied permissions, and showcasing how these settings affect what each user can see and do in the system. The demonstration will illustrate TYPO3's granular control for managing content workflows and editorial processes.
 
-.. _s5-d3-l5-prerequisites-goals:
+.. _s0-d3-l5-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l5-prerequisites:
+.. _s0-d3-l5-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l5-theoretical-prerequisites:
+.. _s0-d3-l5-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-l5-practical-prerequisites:
+.. _s0-d3-l5-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-l5-goals:
+.. _s0-d3-l5-goals:
 
 Goals
 -----
 
-.. _s5-d3-l5-theoretical-goals:
+.. _s0-d3-l5-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d3-l5-practical-goals:
+.. _s0-d3-l5-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d3-l5-resources:
+.. _s0-d3-l5-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l5-teacher:
+.. _s0-d3-l5-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l5-student:
+.. _s0-d3-l5-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-6.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-6.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l6:
+.. _s0-d3-l6:
 
 ==========================================
 Lesson 6 — Multilingual Content Management
@@ -8,19 +8,19 @@ Lesson 6 — Multilingual Content Management
 
 A practical showcase of TYPO3's multilingual capabilities in operation. The demonstration will include configuring language settings, creating translated content, and switching between language versions. The session will illustrate how the system handles translations, language-specific settings, and the user experience for both editors and visitors of multilingual websites.
 
-.. _s5-d3-l6-prerequisites-goals:
+.. _s0-d3-l6-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l6-prerequisites:
+.. _s0-d3-l6-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l6-theoretical-prerequisites:
+.. _s0-d3-l6-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d3-l6-practical-prerequisites:
+.. _s0-d3-l6-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d3-l6-goals:
+.. _s0-d3-l6-goals:
 
 Goals
 -----
 
-.. _s5-d3-l6-theoretical-goals:
+.. _s0-d3-l6-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d3-l6-practical-goals:
+.. _s0-d3-l6-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d3-l6-resources:
+.. _s0-d3-l6-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l6-teacher:
+.. _s0-d3-l6-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l6-student:
+.. _s0-d3-l6-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-7.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-3/Lesson-7.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d3-l7:
+.. _s0-d3-l7:
 
 =============================
 Lesson 7 — Recap and Catch-Up
@@ -8,19 +8,19 @@ Lesson 7 — Recap and Catch-Up
 
 A comprehensive review of the day's content management concepts and their strategic application. This lesson will consolidate key learning points, address questions, and facilitate discussion about effective content organization principles in TYPO3.
 
-.. _s5-d3-l7-prerequisites-goals:
+.. _s0-d3-l7-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d3-l7-prerequisites:
+.. _s0-d3-l7-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d3-l7-theoretical-prerequisites:
+.. _s0-d3-l7-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,7 +30,7 @@ This lesson assumes that you already know the following:
 * The content of today's previous lessons.
 
 
-.. _s5-d3-l7-l7-practical-prerequisites:
+.. _s0-d3-l7-l7-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,12 +41,12 @@ Before you start this lesson, please have the following things ready:
 * A list of any uncompleted tasks from previous lessons (if any) and what you need from the teacher to complete them.
 
 
-.. _s5-d3-l7-goals:
+.. _s0-d3-l7-goals:
 
 Goals
 -----
 
-.. _s5-d3-l7-theoretical-goals:
+.. _s0-d3-l7-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -58,7 +58,7 @@ By the end of this lesson, you should know the following:
 * What to expect for tomorrow.
 
 
-.. _s5-d3-l7-practical-goals:
+.. _s0-d3-l7-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -68,7 +68,7 @@ By the end of this lesson, you should have completed the following:
 * You should have completed any outstanding tasks or know what to do in order to complete them.
 
 
-.. _s5-d3-l7-resources:
+.. _s0-d3-l7-resources:
 
 Learning resources
 ==================
@@ -77,13 +77,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d3-l7-teacher:
+.. _s0-d3-l7-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d3-l7-student:
+.. _s0-d3-l7-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Index.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s0-d4:
 
 ======================================================
 Day 4 — Development to Production: The TYPO3 Lifecycle
 ======================================================
 
-.. _s5-d1-lessons:
+.. _s0-d4-lessons:
 
 Today's lessons
 ===============
@@ -25,19 +25,19 @@ Through practical demonstrations, instructors will show students how TYPO3 proje
     Lesson-7
 
 
-.. _s5-d4-prerequisites-goals:
+.. _s0-d4-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-prerequisites:
+.. _s0-d4-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-theoretical-prerequisites:
+.. _s0-d4-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +49,7 @@ This day assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-practical-prerequisites:
+.. _s0-d4-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,12 +61,12 @@ Before you start this day, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-goals:
+.. _s0-d4-goals:
 
 Goals
 -----
 
-.. _s5-d4-theoretical-goals:
+.. _s0-d4-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ By the end of this day, you should know the following:
 * Item 3
 
 
-.. _s5-d4-practical-goals:
+.. _s0-d4-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-1.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-1.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l1:
+.. _s0-d4-l1:
 
 ===============================================
 Lesson 1 — The TYPO3 Project Lifecycle Overview
@@ -8,19 +8,19 @@ Lesson 1 — The TYPO3 Project Lifecycle Overview
 
 A demonstration of the complete TYPO3 project lifecycle in action. The presentation will visualize progression from concept through development, deployment, and maintenance. This showcase will provide a clear framework for understanding how TYPO3 projects evolve over time.
 
-.. _s5-d4-l1-prerequisites-goals:
+.. _s0-d4-l1-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l1-prerequisites:
+.. _s0-d4-l1-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l1-theoretical-prerequisites:
+.. _s0-d4-l1-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-l1-practical-prerequisites:
+.. _s0-d4-l1-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-l1-goals:
+.. _s0-d4-l1-goals:
 
 Goals
 -----
 
-.. _s5-d4-l1-theoretical-goals:
+.. _s0-d4-l1-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d4-l1-practical-goals:
+.. _s0-d4-l1-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d4-l1-resources:
+.. _s0-d4-l1-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l1-teacher:
+.. _s0-d4-l1-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l1-student:
+.. _s0-d4-l1-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-2.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-2.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l2:
+.. _s0-d4-l2:
 
 ==============================================
 Lesson 2 — Environment Types and Their Purpose
@@ -8,19 +8,19 @@ Lesson 2 — Environment Types and Their Purpose
 
 A comparison of different TYPO3 environments in operation. The demonstration will showcase development, testing, staging, and production environments side by side, highlighting their distinct characteristics. These examples will illustrate how environments work together to ensure quality and stability.
 
-.. _s5-d4-l2-prerequisites-goals:
+.. _s0-d4-l2-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l2-prerequisites:
+.. _s0-d4-l2-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l2-theoretical-prerequisites:
+.. _s0-d4-l2-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-l2-practical-prerequisites:
+.. _s0-d4-l2-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-l2-goals:
+.. _s0-d4-l2-goals:
 
 Goals
 -----
 
-.. _s5-d4-l2-theoretical-goals:
+.. _s0-d4-l2-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d4-l2-practical-goals:
+.. _s0-d4-l2-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d4-l2-resources:
+.. _s0-d4-l2-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l2-teacher:
+.. _s0-d4-l2-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l2-student:
+.. _s0-d4-l2-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-3.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-3.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l3:
+.. _s0-d4-l3:
 
 ================================================
 Lesson 3 — Introduction to Deployment Strategies
@@ -8,19 +8,19 @@ Lesson 3 — Introduction to Deployment Strategies
 
 A demonstration of approaches for moving TYPO3 websites between environments. The showcase will include both manual and automated deployment examples, illustrating the tools and processes involved. This presentation will make deployment concepts tangible for beginners.
 
-.. _s5-d4-l3-prerequisites-goals:
+.. _s0-d4-l3-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l3-prerequisites:
+.. _s0-d4-l3-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l3-theoretical-prerequisites:
+.. _s0-d4-l3-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-l3-practical-prerequisites:
+.. _s0-d4-l3-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-l3-goals:
+.. _s0-d4-l3-goals:
 
 Goals
 -----
 
-.. _s5-d4-l3-theoretical-goals:
+.. _s0-d4-l3-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d4-l3-practical-goals:
+.. _s0-d4-l3-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d4-l3-resources:
+.. _s0-d4-l3-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l3-teacher:
+.. _s0-d4-l3-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l3-student:
+.. _s0-d4-l3-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-4.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-4.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l4:
+.. _s0-d4-l4:
 
 ====================================================
 Lesson 4 — Version Control in the Deployment Process
@@ -8,19 +8,19 @@ Lesson 4 — Version Control in the Deployment Process
 
 A demonstration showing how version control integrates with TYPO3 deployments. The session will showcase Git branches, tags, and workflows in action, demonstrating how code changes progress through environments. Examples will highlight how version control ensures reliable deployments.
 
-.. _s5-d4-l4-prerequisites-goals:
+.. _s0-d4-l4-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l4-prerequisites:
+.. _s0-d4-l4-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l4-theoretical-prerequisites:
+.. _s0-d4-l4-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-l4-practical-prerequisites:
+.. _s0-d4-l4-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-l4-goals:
+.. _s0-d4-l4-goals:
 
 Goals
 -----
 
-.. _s5-d4-l4-theoretical-goals:
+.. _s0-d4-l4-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d4-l4-practical-goals:
+.. _s0-d4-l4-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d4-l4-resources:
+.. _s0-d4-l4-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l4-teacher:
+.. _s0-d4-l4-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l4-student:
+.. _s0-d4-l4-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-5.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-5.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l5:
+.. _s0-d4-l5:
 
 =============================================
 Lesson 5 — Continuous Integration and Testing
@@ -8,19 +8,19 @@ Lesson 5 — Continuous Integration and Testing
 
 A demonstration of continuous integration tools processing TYPO3 code changes. The showcase will include automated tests executing, code quality checks running, and deployment triggering based on results. This presentation will illustrate how automation improves reliability in the deployment process.
 
-.. _s5-d4-l5-prerequisites-goals:
+.. _s0-d4-l5-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l5-prerequisites:
+.. _s0-d4-l5-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l5-theoretical-prerequisites:
+.. _s0-d4-l5-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-l5-practical-prerequisites:
+.. _s0-d4-l5-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-l5-goals:
+.. _s0-d4-l5-goals:
 
 Goals
 -----
 
-.. _s5-d4-l5-theoretical-goals:
+.. _s0-d4-l5-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d4-l5-practical-goals:
+.. _s0-d4-l5-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d4-l5-resources:
+.. _s0-d4-l5-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l5-teacher:
+.. _s0-d4-l5-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l5-student:
+.. _s0-d4-l5-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-6.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-6.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l6:
+.. _s0-d4-l6:
 
 =====================================================
 Lesson 6 — Performance and Scalability Considerations
@@ -8,19 +8,19 @@ Lesson 6 — Performance and Scalability Considerations
 
 A comparative demonstration of TYPO3 performance optimization techniques. The showcase will include before-and-after examples of caching implementation, content delivery networks, and other optimization strategies. Examples will visually demonstrate the impact on website performance.
 
-.. _s5-d4-l6-prerequisites-goals:
+.. _s0-d4-l6-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l6-prerequisites:
+.. _s0-d4-l6-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l6-theoretical-prerequisites:
+.. _s0-d4-l6-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d4-l6-practical-prerequisites:
+.. _s0-d4-l6-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d4-l6-goals:
+.. _s0-d4-l6-goals:
 
 Goals
 -----
 
-.. _s5-d4-l6-theoretical-goals:
+.. _s0-d4-l6-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d4-l6-practical-goals:
+.. _s0-d4-l6-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d4-l6-resources:
+.. _s0-d4-l6-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l6-teacher:
+.. _s0-d4-l6-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l6-student:
+.. _s0-d4-l6-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-7.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-4/Lesson-7.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d4-l7:
+.. _s0-d4-l7:
 
 =============================
 Lesson 7 — Recap and Catch-Up
@@ -8,19 +8,19 @@ Lesson 7 — Recap and Catch-Up
 
 A comprehensive review of the day's deployment concepts and their practical application. This lesson will consolidate key learning points, address questions, and help students begin thinking about deployment strategies for their future TYPO3 projects.
 
-.. _s5-d4-l7-prerequisites-goals:
+.. _s0-d4-l7-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d4-l7-prerequisites:
+.. _s0-d4-l7-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d4-l7-theoretical-prerequisites:
+.. _s0-d4-l7-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,7 +30,7 @@ This lesson assumes that you already know the following:
 * The content of today's previous lessons.
 
 
-.. _s5-d4-l7-l7-practical-prerequisites:
+.. _s0-d4-l7-l7-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,12 +41,12 @@ Before you start this lesson, please have the following things ready:
 * A list of any uncompleted tasks from previous lessons (if any) and what you need from the teacher to complete them.
 
 
-.. _s5-d4-l7-goals:
+.. _s0-d4-l7-goals:
 
 Goals
 -----
 
-.. _s5-d4-l7-theoretical-goals:
+.. _s0-d4-l7-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -58,7 +58,7 @@ By the end of this lesson, you should know the following:
 * What to expect for tomorrow.
 
 
-.. _s5-d4-l7-practical-goals:
+.. _s0-d4-l7-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -68,7 +68,7 @@ By the end of this lesson, you should have completed the following:
 * You should have completed any outstanding tasks or know what to do in order to complete them.
 
 
-.. _s5-d4-l7-resources:
+.. _s0-d4-l7-resources:
 
 Learning resources
 ==================
@@ -77,13 +77,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d4-l7-teacher:
+.. _s0-d4-l7-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d4-l7-student:
+.. _s0-d4-l7-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Index.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s0-d5:
 
 ==============================
 Day 5 — TYPO3 in the Long Term
 ==============================
 
-.. _s5-d1-lessons:
+.. _s0-d5-lessons:
 
 Today's lessons
 ===============
@@ -25,19 +25,19 @@ The final day includes demonstrations of essential maintenance and security prac
     Lesson-7
 
 
-.. _s5-d5-prerequisites-goals:
+.. _s0-d5-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-prerequisites:
+.. _s0-d5-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-theoretical-prerequisites:
+.. _s0-d5-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +49,7 @@ This day assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-practical-prerequisites:
+.. _s0-d5-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,12 +61,12 @@ Before you start this day, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-goals:
+.. _s0-d5-goals:
 
 Goals
 -----
 
-.. _s5-d5-theoretical-goals:
+.. _s0-d5-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ By the end of this day, you should know the following:
 * Item 3
 
 
-.. _s5-d5-practical-goals:
+.. _s0-d5-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-1.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-1.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l1:
+.. _s0-d5-l1:
 
 ===========================================
 Lesson 1 — TYPO3's Update and Release Cycle
@@ -8,19 +8,19 @@ Lesson 1 — TYPO3's Update and Release Cycle
 
 A demonstration of TYPO3's release process and updates in action. The presentation will showcase different release types and their installation procedures. This practical session will illustrate how the predictable release cycle supports sustainable website management.
 
-.. _s5-d5-l1-prerequisites-goals:
+.. _s0-d5-l1-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l1-prerequisites:
+.. _s0-d5-l1-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l1-theoretical-prerequisites:
+.. _s0-d5-l1-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-l1-practical-prerequisites:
+.. _s0-d5-l1-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-l1-goals:
+.. _s0-d5-l1-goals:
 
 Goals
 -----
 
-.. _s5-d5-l1-theoretical-goals:
+.. _s0-d5-l1-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d5-l1-practical-goals:
+.. _s0-d5-l1-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d5-l1-resources:
+.. _s0-d5-l1-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l1-teacher:
+.. _s0-d5-l1-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l1-student:
+.. _s0-d5-l1-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-2.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-2.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l2:
+.. _s0-d5-l2:
 
 ==========================================
 Lesson 2 — Security Fundamentals for TYPO3
@@ -8,19 +8,19 @@ Lesson 2 — Security Fundamentals for TYPO3
 
 A live demonstration of TYPO3's security features and vulnerabilities. The showcase will include security bulletins, patch applications, and prevention techniques. The presentation will demonstrate how the TYPO3 community addresses security concerns in real-world scenarios.
 
-.. _s5-d5-l2-prerequisites-goals:
+.. _s0-d5-l2-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l2-prerequisites:
+.. _s0-d5-l2-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l2-theoretical-prerequisites:
+.. _s0-d5-l2-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-l2-practical-prerequisites:
+.. _s0-d5-l2-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-l2-goals:
+.. _s0-d5-l2-goals:
 
 Goals
 -----
 
-.. _s5-d5-l2-theoretical-goals:
+.. _s0-d5-l2-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d5-l2-practical-goals:
+.. _s0-d5-l2-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d5-l2-resources:
+.. _s0-d5-l2-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l2-teacher:
+.. _s0-d5-l2-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l2-student:
+.. _s0-d5-l2-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-3.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-3.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l3:
+.. _s0-d5-l3:
 
 =============================================
 Lesson 3 — User Management and Access Control
@@ -8,19 +8,19 @@ Lesson 3 — User Management and Access Control
 
 A practical demonstration of TYPO3's permission system in operation. The showcase will illustrate different user configurations and their impact on system security. Examples will demonstrate how proper access control contributes to overall website protection.
 
-.. _s5-d5-l3-prerequisites-goals:
+.. _s0-d5-l3-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l3-prerequisites:
+.. _s0-d5-l3-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l3-theoretical-prerequisites:
+.. _s0-d5-l3-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-l3-practical-prerequisites:
+.. _s0-d5-l3-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-l3-goals:
+.. _s0-d5-l3-goals:
 
 Goals
 -----
 
-.. _s5-d5-l3-theoretical-goals:
+.. _s0-d5-l3-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d5-l3-practical-goals:
+.. _s0-d5-l3-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d5-l3-resources:
+.. _s0-d5-l3-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l3-teacher:
+.. _s0-d5-l3-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l3-student:
+.. _s0-d5-l3-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-4.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-4.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l4:
+.. _s0-d5-l4:
 
 ==================================================
 Lesson 4 — Backup Strategies and Disaster Recovery
@@ -8,19 +8,19 @@ Lesson 4 — Backup Strategies and Disaster Recovery
 
 A step-by-step demonstration of backup creation and restoration processes. The presentation will include database exports, file system backups, and configuration preservation. This practical showcase will illustrate recovery procedures for different emergency scenarios.
 
-.. _s5-d5-l4-prerequisites-goals:
+.. _s0-d5-l4-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l4-prerequisites:
+.. _s0-d5-l4-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l4-theoretical-prerequisites:
+.. _s0-d5-l4-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-l4-practical-prerequisites:
+.. _s0-d5-l4-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-l4-goals:
+.. _s0-d5-l4-goals:
 
 Goals
 -----
 
-.. _s5-d5-l4-theoretical-goals:
+.. _s0-d5-l4-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d5-l4-practical-goals:
+.. _s0-d5-l4-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d5-l4-resources:
+.. _s0-d5-l4-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l4-teacher:
+.. _s0-d5-l4-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l4-student:
+.. _s0-d5-l4-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-5.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-5.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l5:
+.. _s0-d5-l5:
 
 ==================================================
 Lesson 5 — Performance Monitoring and Optimization
@@ -8,19 +8,19 @@ Lesson 5 — Performance Monitoring and Optimization
 
 A comparative demonstration of performance monitoring tools in action. The showcase will include before-and-after examples of optimization techniques. The presentation will illustrate how ongoing performance management maintains optimal site functionality.
 
-.. _s5-d5-l5-prerequisites-goals:
+.. _s0-d5-l5-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l5-prerequisites:
+.. _s0-d5-l5-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l5-theoretical-prerequisites:
+.. _s0-d5-l5-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-l5-practical-prerequisites:
+.. _s0-d5-l5-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-l5-goals:
+.. _s0-d5-l5-goals:
 
 Goals
 -----
 
-.. _s5-d5-l5-theoretical-goals:
+.. _s0-d5-l5-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d5-l5-practical-goals:
+.. _s0-d5-l5-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d5-l5-resources:
+.. _s0-d5-l5-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l5-teacher:
+.. _s0-d5-l5-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l5-student:
+.. _s0-d5-l5-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-6.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-6.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l6:
+.. _s0-d5-l6:
 
 ========================================================
 Lesson 6 — Planning for Long-term Growth and Scalability
@@ -8,19 +8,19 @@ Lesson 6 — Planning for Long-term Growth and Scalability
 
 A visual demonstration of how TYPO3 websites evolve over time. The showcase will include examples of sites that have scaled successfully. This presentation will illustrate strategic approaches to content growth and technical sustainability.
 
-.. _s5-d5-l6-prerequisites-goals:
+.. _s0-d5-l6-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l6-prerequisites:
+.. _s0-d5-l6-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l6-theoretical-prerequisites:
+.. _s0-d5-l6-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ This lesson assumes that you already know the following:
 * Item 3
 
 
-.. _s5-d5-l6-practical-prerequisites:
+.. _s0-d5-l6-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,12 +44,12 @@ Before you start this lesson, please have the following things ready:
 * Item 3
 
 
-.. _s5-d5-l6-goals:
+.. _s0-d5-l6-goals:
 
 Goals
 -----
 
-.. _s5-d5-l6-theoretical-goals:
+.. _s0-d5-l6-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ By the end of this lesson, you should know the following:
 * Item 3
 
 
-.. _s5-d5-l6-practical-goals:
+.. _s0-d5-l6-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -73,7 +73,7 @@ By the end of this lesson, you should have completed the following:
 * Item 3
 
 
-.. _s5-d5-l6-resources:
+.. _s0-d5-l6-resources:
 
 Learning resources
 ==================
@@ -82,13 +82,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l6-teacher:
+.. _s0-d5-l6-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l6-student:
+.. _s0-d5-l6-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-7.rst
+++ b/Documentation/Stage-0-Introduction-to-TYPO3/Day-5/Lesson-7.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d5-l7:
+.. _s0-d5-l7:
 
 =============================
 Lesson 7 — Recap and Catch-Up
@@ -8,19 +8,19 @@ Lesson 7 — Recap and Catch-Up
 
 A thorough recap of the entire introductory stage, reinforcing key concepts from all five days. This lesson will consolidate learning, address remaining questions, and prepare students for the hands-on implementation work that begins in Stage 1.
 
-.. _s5-d5-l7-prerequisites-goals:
+.. _s0-d5-l7-prerequisites-goals:
 
 Prerequisites and goals
 =======================
 
 
-.. _s5-d5-l7-prerequisites:
+.. _s0-d5-l7-prerequisites:
 
 Prerequisites
 -------------
 
 
-.. _s5-d5-l7-theoretical-prerequisites:
+.. _s0-d5-l7-theoretical-prerequisites:
 
 Theoretical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,7 +30,7 @@ This lesson assumes that you already know the following:
 * The content of today's previous lessons.
 
 
-.. _s5-d5-l7-l7-practical-prerequisites:
+.. _s0-d5-l7-l7-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,12 +41,12 @@ Before you start this lesson, please have the following things ready:
 * A list of any uncompleted tasks from previous lessons (if any) and what you need from the teacher to complete them.
 
 
-.. _s5-d5-l7-goals:
+.. _s0-d5-l7-goals:
 
 Goals
 -----
 
-.. _s5-d5-l7-theoretical-goals:
+.. _s0-d5-l7-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -58,7 +58,7 @@ By the end of this lesson, you should know the following:
 * What to expect for tomorrow.
 
 
-.. _s5-d5-l7-practical-goals:
+.. _s0-d5-l7-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~
@@ -68,7 +68,7 @@ By the end of this lesson, you should have completed the following:
 * You should have completed any outstanding tasks or know what to do in order to complete them.
 
 
-.. _s5-d5-l7-resources:
+.. _s0-d5-l7-resources:
 
 Learning resources
 ==================
@@ -77,13 +77,13 @@ Learning resources
 * :ref:`Users and groups <t3coreapi:access-users-groups>`
 
 
-.. _s5-d5-l7-teacher:
+.. _s0-d5-l7-teacher:
 
 Teacher's instructions
 ======================
 
 
-.. _s5-d5-l7-student:
+.. _s0-d5-l7-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-1-Installation/Day-2/Index.rst
+++ b/Documentation/Stage-1-Installation/Day-2/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s1-d1:
+.. _s1-d2:
 
 ======================
 Day 2 — DDEV and TYPO3
 ======================
 
-.. _s1-d1-lessons:
+.. _s1-d2-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-1-Installation/Day-3/Index.rst
+++ b/Documentation/Stage-1-Installation/Day-3/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s1-d1:
+.. _s1-d3:
 
 ========================
 Day 3 — Composer and Git
 ========================
 
-.. _s1-d1-lessons:
+.. _s1-d3-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-1-Installation/Day-4/Index.rst
+++ b/Documentation/Stage-1-Installation/Day-4/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s1-d1:
+.. _s1-d4:
 
 ===========================
 Day 4 — Bootstrap and TYPO3
 ===========================
 
-.. _s1-d1-lessons:
+.. _s1-d4-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-1-Installation/Day-5/Index.rst
+++ b/Documentation/Stage-1-Installation/Day-5/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s1-d1:
+.. _s1-d5:
 
 ============================
 Day 5 — Recap and assessment
 ============================
 
-.. _s1-d1-lessons:
+.. _s1-d5-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-2-Customization/Day-2/Index.rst
+++ b/Documentation/Stage-2-Customization/Day-2/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s2-d1:
+.. _s2-d2:
 
 =============================================
 Day 2 — Editing and customizing TYPO3 content
 =============================================
 
-.. _s2-d1-lessons:
+.. _s2-d2-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-2-Customization/Day-3/Index.rst
+++ b/Documentation/Stage-2-Customization/Day-3/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s2-d1:
+.. _s2-d3:
 
 ==============================================
 Day 3 — Advanced TYPO3 concepts and typoscript
 ==============================================
 
-.. _s2-d1-lessons:
+.. _s2-d3-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-2-Customization/Day-4/Index.rst
+++ b/Documentation/Stage-2-Customization/Day-4/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s2-d1:
+.. _s2-d4:
 
 =============================================================
 Day 4 — Working with Fluid templates and the Rich Text Editor
 =============================================================
 
-.. _s2-d1-lessons:
+.. _s2-d4-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-2-Customization/Day-5/Index.rst
+++ b/Documentation/Stage-2-Customization/Day-5/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s2-d1:
+.. _s2-d5:
 
 =========================================================
 Day 5 — Creating and configuring a site package extension
 =========================================================
 
-.. _s2-d1-lessons:
+.. _s2-d5-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-3-Deployment/Day-2/Index.rst
+++ b/Documentation/Stage-3-Deployment/Day-2/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s3-d1:
+.. _s3-d2:
 
 ====================================================
 Day 2 — Testing Environments and Database Management
 ====================================================
 
-.. _s3-d1-lessons:
+.. _s3-d2-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-3-Deployment/Day-3/Index.rst
+++ b/Documentation/Stage-3-Deployment/Day-3/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s3-d1:
+.. _s3-d3:
 
 ===========================================================
 Day 3 — Advanced CI/CD Implementation and Quality Assurance
 ===========================================================
 
-.. _s3-d1-lessons:
+.. _s3-d3-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-3-Deployment/Day-4/Index.rst
+++ b/Documentation/Stage-3-Deployment/Day-4/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s3-d1:
+.. _s3-d4:
 
 =================================================
 Day 4 — Practical Application and Troubleshooting
 =================================================
 
-.. _s3-d1-lessons:
+.. _s3-d4-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-3-Deployment/Day-5/Index.rst
+++ b/Documentation/Stage-3-Deployment/Day-5/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s3-d1:
+.. _s3-d5:
 
 =============================================
 Day 5 — Review, Q&A, and Project Presentation
 =============================================
 
-.. _s3-d1-lessons:
+.. _s3-d5-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-4-Maintenance-and-Security/Day-2/Index.rst
+++ b/Documentation/Stage-4-Maintenance-and-Security/Day-2/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s4-d1:
+.. _s4-d2:
 
 ====================================
 Day 2 — Performing Upgrades on TYPO3
 ====================================
 
-.. _s4-d1-lessons:
+.. _s4-d2-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-4-Maintenance-and-Security/Day-3/Index.rst
+++ b/Documentation/Stage-4-Maintenance-and-Security/Day-3/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s4-d1:
+.. _s4-d3:
 
 =========================================================
 Day 3 — TYPO3 Security Enhancements and System Monitoring
 =========================================================
 
-.. _s4-d1-lessons:
+.. _s4-d3-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-4-Maintenance-and-Security/Day-4/Index.rst
+++ b/Documentation/Stage-4-Maintenance-and-Security/Day-4/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s4-d1:
+.. _s4-d4:
 
 ==================================================
 Day 4 — Managing Security in TYPO3 and Custom Code
 ==================================================
 
-.. _s4-d1-lessons:
+.. _s4-d4-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-4-Maintenance-and-Security/Day-5/Index.rst
+++ b/Documentation/Stage-4-Maintenance-and-Security/Day-5/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s4-d1:
+.. _s4-d5:
 
 ======================================
 Day 5 — Crisis management and recovery
 ======================================
 
-.. _s4-d1-lessons:
+.. _s4-d5-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-5-Project-Implementation/Day-1/Lesson-1.rst
+++ b/Documentation/Stage-5-Project-Implementation/Day-1/Lesson-1.rst
@@ -87,7 +87,7 @@ Teacher's instructions
 ======================
 
 
-.. _s0-d1-l1-student:
+.. _s5-d1-l1-student:
 
 Student's instructions
 ======================

--- a/Documentation/Stage-5-Project-Implementation/Day-2/Index.rst
+++ b/Documentation/Stage-5-Project-Implementation/Day-2/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s5-d2:
 
 =================
 Day 2 — ADD TITLE
 =================
 
-.. _s5-d1-lessons:
+.. _s5-d2-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-5-Project-Implementation/Day-3/Index.rst
+++ b/Documentation/Stage-5-Project-Implementation/Day-3/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s5-d3:
 
 =================
 Day 3 — ADD TITLE
 =================
 
-.. _s5-d1-lessons:
+.. _s5-d3-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-5-Project-Implementation/Day-4/Index.rst
+++ b/Documentation/Stage-5-Project-Implementation/Day-4/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s5-d4:
 
 =================
 Day 4 — ADD TITLE
 =================
 
-.. _s5-d1-lessons:
+.. _s5-d4-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-5-Project-Implementation/Day-5/Index.rst
+++ b/Documentation/Stage-5-Project-Implementation/Day-5/Index.rst
@@ -1,12 +1,12 @@
 .. include:: /Includes.rst.txt
 
-.. _s5-d1:
+.. _s5-d5:
 
 =================
 Day 5 — ADD TITLE
 =================
 
-.. _s5-d1-lessons:
+.. _s5-d5-lessons:
 
 Today's lessons
 ===============

--- a/Documentation/Stage-5-Project-Implementation/Index.rst
+++ b/Documentation/Stage-5-Project-Implementation/Index.rst
@@ -46,7 +46,7 @@ This stage assumes that you already know the following:
 * How to implement security and collaboration practices for quality assurance in development and emergency handling in production.
 
 
-.. _s0-practical-prerequisites:
+.. _s5-practical-prerequisites:
 
 Practical prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,12 +56,12 @@ Before you start this stage, please have the following things ready:
 * Local development environment with a local version of a live TYPO3 installation, connected through a continuous integration and continuous deployment pipeline.
 
 
-.. _s0-goals:
+.. _s5-goals:
 
 Goals
 -----
 
-.. _s0-theoretical-goals:
+.. _s5-theoretical-goals:
 
 Theoretical goals
 ~~~~~~~~~~~~~~~~~
@@ -79,7 +79,7 @@ By the end of this stage, you should know the following:
 * How to report bugs in the TYPO3 core, including how to safely deal with security-related issues
 
 
-.. _s0-practical-goals:
+.. _s5-practical-goals:
 
 Practical goals
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Removing all duplicate anchor names. Errors were reported by the renderer.